### PR TITLE
build_feed: drop -i flag

### DIFF
--- a/build_feed
+++ b/build_feed
@@ -26,7 +26,7 @@ else
 
   docker pull "$IMAGE"
   mkdir -p "$OUTPUT_DIR"
-  docker run --rm -it \
+  docker run --rm \
 	  -v "$(pwd)/build_feed:/home/build/openwrt/build_feed" \
 	  -v "$OUTPUT_DIR/:/home/build/openwrt/bin" \
 	  -e "FEED_LINE=$FEED_LINE" \


### PR DESCRIPTION
docker refuses to run in a buildbot-worker-session due
to the -i flag. As we do not pipe anything into the
docker-command, we can safely drop it.